### PR TITLE
Updated Flask version to fix dependency issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ In order to demonstrate a CloudWatch Alarm, this application allows the user to 
 
 ### Installing
 
-This application is referenced by a Cloudformation template that will install it.
+This application is referenced by a CloudFormation template that will install it.  
+e.g. [AWS Modernization Workshop](https://github.com/aws-samples/aws-modernization-workshop-sample/blob/master/code-samples/cloudformation/sample-web-app/Demo-noasg.yml)
 
 ## Version History
 
 * 0.1
     * Initial Release
+* 0.2
+    * Upgrade of Flask version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
+Flask==2.1.0
 python-dotenv==0.13.0
 #uwsgi==2.0.18
 gunicorn


### PR DESCRIPTION
## Summary
This PR addresses a dependency issue with Jinja2 for the specified version of Flask.
As a result, running WSGI under gunicorn fails, preventing the service from running under systemd.

Ref: https://stackoverflow.com/questions/71718167/importerror-cannot-import-name-escape-from-jinja2/71735103#71735103 

The newer version of Flask no longer uses the escape module from Jinja and allows gunicorn to run correctly.